### PR TITLE
Fix project card hover effect on iPad touch devices

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -401,11 +401,36 @@ const pastWork: readonly PastWorkItem[] = [
   },
 ];
 
+function useCanHover() {
+  const [canHover, setCanHover] = useState(true);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const hoverQuery = window.matchMedia("(hover: hover) and (pointer: fine)");
+    const update = () => {
+      setCanHover(hoverQuery.matches);
+    };
+
+    update();
+    hoverQuery.addEventListener("change", update);
+
+    return () => {
+      hoverQuery.removeEventListener("change", update);
+    };
+  }, []);
+
+  return canHover;
+}
+
 function Component() {
   const cardRefs = useRef<Array<HTMLElement | null>>([]);
   const [activeCard, setActiveCard] = useState<number | null>(null);
   const [shimmerCards, setShimmerCards] = useState<number[]>([]);
   const [adjacentCards, setAdjacentCards] = useState<number[]>([]);
+  const canHover = useCanHover();
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -565,8 +590,25 @@ function Component() {
     };
   }, []);
 
+  useEffect(() => {
+    if (canHover) {
+      return;
+    }
+
+    const handleDocumentClick = () => {
+      setActiveCard(null);
+      setAdjacentCards([]);
+    };
+
+    document.addEventListener("click", handleDocumentClick);
+
+    return () => {
+      document.removeEventListener("click", handleDocumentClick);
+    };
+  }, [canHover]);
+
   const handleCardEnter = (index: number) => {
-    if (typeof window !== "undefined" && window.matchMedia("(max-width: 639px)").matches) {
+    if (!canHover) {
       return;
     }
 
@@ -580,11 +622,33 @@ function Component() {
   };
 
   const handleCardLeave = () => {
-    if (typeof window !== "undefined" && window.matchMedia("(max-width: 639px)").matches) {
+    if (!canHover) {
       return;
     }
 
     setAdjacentCards([]);
+  };
+
+  const handleCardActivate = (index: number) => {
+    if (canHover) {
+      return;
+    }
+
+    const nextActive = activeCard === index ? null : index;
+    setActiveCard(nextActive);
+
+    if (nextActive === null) {
+      setAdjacentCards([]);
+      return;
+    }
+
+    const cards = cardRefs.current.filter((card): card is HTMLElement => card !== null);
+
+    if (cards.length === 0) {
+      return;
+    }
+
+    setAdjacentCards(getAdjacentCardIndexes(getCardGridPositions(cards), index));
   };
 
   return (
@@ -680,6 +744,10 @@ function Component() {
                   handleCardEnter(index);
                 }}
                 onMouseLeave={handleCardLeave}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  handleCardActivate(index);
+                }}
                 data-active={activeCard === index ? "true" : "false"}
                 className="transition-transform duration-700 ease-out sm:hover:scale-[1.015] data-[active=true]:scale-[1.015]"
               >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On iPad, project cards did not show the bold brand color hover effect. The cards rely on CSS `:hover` styles gated behind the `sm:` breakpoint, but iPad viewports are wide enough to use those styles while touch input does not trigger hover.

Mobile phones already worked via scroll-based `data-active` state, but that logic only runs below 640px — so iPad fell into a gap where neither hover nor scroll activation applied.

## Solution

Detect whether the device supports true hover (`(hover: hover) and (pointer: fine)`):

- **Mouse/trackpad devices** (desktop, iPad with Magic Keyboard): keep existing CSS hover behavior
- **Touch-primary devices** (iPad finger touch, phones in landscape): tap a card to activate the same `data-active` state used on mobile, including adjacent card dimming

Tapping the same card again or tapping outside the cards clears the active state.

## Testing

- `npm run build` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2bfd16dc-f92f-46e6-811d-fff7d069a6c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2bfd16dc-f92f-46e6-811d-fff7d069a6c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

